### PR TITLE
fix(dependabot): thanks but no thanks dependabot

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:16.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM centos:7
 
 RUN yum update -y && \
     yum -y install \


### PR DESCRIPTION
we need to stay pinned to the oldest release we build because forwards compatibility is easier than backwards