### PR TITLE
chore(deps) add boringssl dependencies - FT-2342

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -24,5 +24,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         ssh \
         valgrind \
         cmake \
+        ninja-build \
     && curl -sSL https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_amd64 -o /usr/local/bin/yaml \
+    && curl -sSL https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o /tmp/go.tar.gz \
+    && cd /tmp && tar -xf go.tar.gz && rm go.tar.gz \
     && chmod +x /usr/local/bin/yaml
+
+ENV GOROOT=/tmp/go
+ENV PATH=$GOROOT/bin:$PATH


### PR DESCRIPTION
Ensure boringssl dependencies are present.

Since the boringssl builds require a more recent Go version than available in the Ubuntu 16.04 repositories, this PR also downloads and adds it to the base image.