### PR TITLE
chore(deps): bump alpine and debian bases

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.16.0
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
### Summary

Bump alpine from 3.8 to 3.16, bump ubuntu from 16.04 to 18.04

Kong-build-tools is the primary user of these dockerfiles and they are pinned so if the changes are breaking the active CI paths should be fine