### PR TITLE
[ENGEN-451] chore(xenial) 👋

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \


### PR DESCRIPTION
### Summary

Use Ubuntu Bionic aka 18.04 (instead of Xenial aka 16.04) where applicable.
The arm64 build (using docker-machine / AWS) was working for me locally.
We don't seem to have automation to exrcise that part of the build.