### PR TITLE
chore(deps) bump `yaml` to 2.1.1

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -26,8 +26,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         cmake \
         ninja-build \
         golang-1.13 \
-    &&  curl -sSL https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_$(dpkg --print-architecture) -o /usr/local/bin/yaml \
-    && chmod +x /usr/local/bin/yaml
+    &&  curl -sSL https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_$(dpkg --print-architecture) -o /usr/local/bin/yaml \
+    &&  chmod +x /usr/local/bin/yaml \
+    &&  yaml --version
 
 ENV GOROOT=/usr/lib/go-1.13
 ENV PATH=$GOROOT/bin:$PATH


### PR DESCRIPTION
### Summary

PR #41 added the correct command to pull arm64 binaries, but the old version we were at doesn't have arm64 builds. This bumps to a more recent version, that still has compatibility with the feature set we rely upon (contrary to versions > v3.0).