### PR TITLE
Revert "chore(deps): bump alpine and debian bases"

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -1,4 +1,4 @@
-FROM alpine:3.16.0
+FROM alpine:3.8
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
Reverts Kong/kong-build-tools-base-images#39

Looks like https://app.travis-ci.com/github/Kong/kong-distributions/jobs/572662423 fails, we didn't actually pin it on PR. Temporary revert this to make the CI happy.