### PR TITLE
feat(luajit): install luajit on our base images

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -36,6 +36,7 @@ RUN apk update \
         unzip \
         xz \
         zlib-dev \
+        luajit \
     && sed -i'' 's/^mozilla\/DST_Root_CA_X3.crt$/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf \
     && update-ca-certificates \
     && curl -sSL https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_amd64 -o /usr/local/bin/yaml \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -27,6 +27,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         unzip \
         valgrind \
         zlib1g-dev \
+        luajit \
     &&  curl -sSL https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_$(dpkg --print-architecture) -o /usr/local/bin/yaml \
     &&  chmod +x /usr/local/bin/yaml \
     &&  yaml --version \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -25,6 +25,7 @@ RUN yum -y install epel-release && \
         unzip \
         wget \
         zlib-devel \
+        luajit \
     && ln -s /usr/bin/cmake3 /usr/bin/cmake \
     && curl -sSL https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_amd64 -o /usr/local/bin/yaml \
     && chmod +x /usr/local/bin/yaml \


### PR DESCRIPTION
we desire luajit on our base images so we can test dynamic libraries as we build them such as atc-router
```
luajit -e 'require("ffi").load "/usr/local/openresty/lualib/libatc_router.so"'
```