### PR TITLE
fix(cmake3): we require cmake3 from source refs: #FTI-4286

### DIFF
--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -43,6 +43,10 @@ RUN curl -fsSLo /tmp/yaml-0.2.5.tar.gz https://pyyaml.org/download/libyaml/yaml-
     && make install \
     && rm -rf /tmp/yaml-0.2.5
 
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-linux-`uname -m`.sh && \
+    chmod +x ./cmake-3*.sh && \
+    ./cmake-3* -- --skip-license --prefix=/usr/local
+
 RUN bash --version && \
     cmake --version && \
     yaml --version


### PR DESCRIPTION
### Summary

Before
```
docker run -it --rm kong/kong-build-tools:rpm cmake --version
CMake Error: Could not find CMAKE_ROOT !!!
CMake has most likely not been installed correctly.
Modules directory not found in
/usr/local/share/cmake-3.24
cmake version 3.24.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).

```

After
```
docker run -it --rm kong/kong-build-tools:rpm cmake --version
cmake version 3.24.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
Sample docker image built from this base image `kong/kong-gateway-internal:FTI-4286`